### PR TITLE
Implemented behavior described in #11

### DIFF
--- a/src/lib/Herrera/Wise/Loader/AbstractFileLoader.php
+++ b/src/lib/Herrera/Wise/Loader/AbstractFileLoader.php
@@ -162,14 +162,16 @@ abstract class AbstractFileLoader extends FileLoader implements ResourceAwareInt
 
                 $this->setCurrentDir($dir);
 
-                $data = array_replace_recursive(
-                    $this->import(
-                        $import['resource'],
-                        null,
-                        isset($import['ignore_errors']) ? (bool) $import['ignore_errors'] : false
-                    ),
-                    $data
-                );
+                if ($imported = $this->import(
+                    $import['resource'],
+                    null,
+                    isset($import['ignore_errors']) ? (bool) $import['ignore_errors'] : false
+                )) {
+                    $data = array_replace_recursive(
+                        is_array($imported) ? $imported : array(),
+                        $data
+                    );
+                };
             }
         }
 


### PR DESCRIPTION
Run `array_replace_recursive` only when resource import succeeded. This change should prevent any warnings occurrence when the imported resource does not exist and `ignore_errors` is set to true.
